### PR TITLE
[Fix]注文情報入力画面

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -33,6 +33,9 @@ class Public::OrdersController < ApplicationController
       @order.shipping_name = params[:order][:shipping_name]
       @order.shipping_postal_code = params[:order][:shipping_postal_code]
       @order.shipping_address = params[:order][:shipping_address]
+      if @order.shipping_name.blank? || @order.shipping_postal_code.blank? || @order.shipping_address.blank?
+        redirect_to request.referer
+      end
     end
   end
 

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -10,7 +10,7 @@
 
   <div><strong>お届け先</strong></div>
 
-  <%= f.radio_button :select_address, 0, checked: true%>
+  <%= f.radio_button :select_address, 0 ,checked: true%>
   <%= f.label :select_address_0, "ご自身の住所" %><br>
   <%= '〒' + current_customer.postal_code %>
   <%= current_customer.address %><br>


### PR DESCRIPTION
注文情報入力画面について以下変更をいたしました。
ご確認お願い致します。
　配送先が登録されていない場合→配送先選択のラジオボタンを表示させない
　新しいお届け先が空欄の場合→入力画面に戻ってくるようにする