### PR TITLE
[Fix]管理者のログアウト後の遷移先と会員新規登録後のリダイレクト先変更2

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,16 @@ class ApplicationController < ActionController::Base
     before_action :authenticate_admin!, if: -> { request.path =~ /^\/admin/ }
     before_action :authenticate_customer!, if: -> { request.path =~ /^\/customer/ }
 
-#   private
+  private
+  def after_sign_out_path_for(resource_or_scope)
+    if resource_or_scope == :customer
+        root_path
+    elsif resource_or_scope == :admin
+        new_admin_session_path
+    else
+        root_path
+    end
+  end
 
 #   def admin_url
 #      request.fullpath.include?("/admin")

--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -4,6 +4,9 @@ class Public::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
+  def after_sign_up_path_for(resource)
+    my_page_customers_path
+  end
   # GET /resource/sign_up
   # def new
   #   super


### PR DESCRIPTION
①管理者のログアウト後と会員のログアウト後の遷移先をそれぞれif文で分岐
②会員の新規登録後の遷移先をマイページに変更

上記完了したのでご確認お願いします。